### PR TITLE
Fix read_gsf.py so that it can still read CASTEP files

### DIFF
--- a/pyDis/pn/read_gsf.py
+++ b/pyDis/pn/read_gsf.py
@@ -99,6 +99,13 @@ def get_gsf_energy(energy_regex, prog, base_name, suffix, i, j=None, indir=False
             else:
                 E = np.nan
                 units = None
+
+        else: 
+            # Other codes - we don't check for convergence, perhapse we should
+            for match in matched_energies:
+                # We want the last match in the file.
+                E = float(match[0])
+                units = match[1]
         
     return E, units
         


### PR DESCRIPTION
read_gsf stopped reading CASTEP output. This is probably the simplest fix but we could do better and it isn't tested with QE. Whatever this should look like in the end, it is probably worth merging this now.
