### PR TITLE
Fix for python numpy version 1.12.1

### DIFF
--- a/pyDis/atomic/circleConstruct.py
+++ b/pyDis/atomic/circleConstruct.py
@@ -21,8 +21,8 @@ def grid(radius,cellParams):
     a = L.norm(cellParams[0])
     b = L.norm(cellParams[1])
     
-    Nx = ceiling(float(radius)/a)
-    Ny = ceiling(float(radius)/b)
+    Nx = int(ceiling(float(radius)/a))
+    Ny = int(ceiling(float(radius)/b))
     return np.ones((2*Ny+1,2*Nx+1))
     
 def centre(x1,x2):


### PR DESCRIPTION
Np.ones does not like float for Nx and Ny. Added int to line.

We ran into a problem with the newest version of numpy, fix made, can this be changed.